### PR TITLE
fix: implement null check for pulling in target vector calculation

### DIFF
--- a/src/main/java/net/jmb19905/niftycarts/entity/AbstractDrawnEntity.java
+++ b/src/main/java/net/jmb19905/niftycarts/entity/AbstractDrawnEntity.java
@@ -392,6 +392,10 @@ public abstract class AbstractDrawnEntity extends Entity {
      * Relative to the cart position.
      */
     public Vec3 getRelativeTargetVec(final float delta) {
+        if(this.pulling == null) {
+            return Vec3.ZERO;
+        }
+        
         final double x;
         final double y;
         final double z;


### PR DESCRIPTION
Add null check for pulling in getRelativeTargetVec method - frequently causes server crashes for me